### PR TITLE
FX68 fix for newer verilator.

### DIFF
--- a/sim/fx68x_verilator/fx68k.sv
+++ b/sim/fx68x_verilator/fx68k.sv
@@ -1346,7 +1346,7 @@ localparam REG_DT = 17;
 		{abhIdle, ablIdle, abdIdle} = '0;
 		{dbhIdle, dblIdle, dbdIdle} = '0;
 
-		unique case( 1'b1)
+		priority case( 1'b1)
 		ryl2Dbd:				dbdMux = regs68L[ actualRy];
 		rxl2Dbd:				dbdMux = regs68L[ actualRx];
 		Nanod2.alue2Dbd:			dbdMux = alue;
@@ -1356,7 +1356,7 @@ localparam REG_DT = 17;
 		default: begin			dbdMux = 'X;	dbdIdle = 1'b1;				end
 		endcase
 
-		unique case( 1'b1)
+		priority case( 1'b1)
 		rxl2Dbl:				dblMux = regs68L[ actualRx];
 		ryl2Dbl:				dblMux = regs68L[ actualRy];
 		Nanod.ftu2Dbl:			dblMux = ftu;
@@ -1366,7 +1366,7 @@ localparam REG_DT = 17;
 		default: begin			dblMux = 'X;	dblIdle = 1'b1;				end
 		endcase
 
-		unique case( 1'b1)
+		priority case( 1'b1)
 		Nanod2.rxh2dbh:			dbhMux = regs68H[ actualRx];
 		Nanod2.ryh2dbh:			dbhMux = regs68H[ actualRy];
 		Nanod.au2Db:			dbhMux = auReg[31:16];
@@ -1375,7 +1375,7 @@ localparam REG_DT = 17;
 		default: begin			dbhMux = 'X;	dbhIdle = 1'b1;				end
 		endcase
 
-		unique case( 1'b1)
+		priority case( 1'b1)
 		ryl2Abd:				abdMux = regs68L[ actualRy];
 		rxl2Abd:				abdMux = regs68L[ actualRx];
 		Nanod.dbin2Abd:			abdMux = dbin;
@@ -1383,7 +1383,7 @@ localparam REG_DT = 17;
 		default: begin			abdMux = 'X;	abdIdle = 1'b1;				end
 		endcase
 
-		unique case( 1'b1)
+		priority case( 1'b1)
 		Pcl2Abl:				ablMux = PcL;
 		rxl2Abl:				ablMux = regs68L[ actualRx];
 		ryl2Abl:				ablMux = regs68L[ actualRy];
@@ -1394,7 +1394,7 @@ localparam REG_DT = 17;
 		default: begin			ablMux = 'X;	ablIdle = 1'b1;				end
 		endcase
 
-		unique case( 1'b1)
+		priority case( 1'b1)
 		Pch2Abh:				abhMux = PcH;
 		Nanod2.rxh2abh:			abhMux = regs68H[ actualRx];
 		Nanod2.ryh2abh:			abhMux = regs68H[ actualRy];

--- a/sim/fx68x_verilator/fx68kAlu.sv
+++ b/sim/fx68x_verilator/fx68kAlu.sv
@@ -310,7 +310,7 @@ module fx68kAlu ( input clk, pwrUp, enT1, enT3, enT4,
 		ccrTemp[ ZF] = isByte ? ~(| result[7:0]) : ~(| result);
 		ccrTemp[ NF] = isByte ? result[7] : result[15];
 
-		unique case( oper)
+		unique0 case( oper)
 		
 		OP_EXT:
 			// Division overflow.
@@ -533,23 +533,23 @@ module aluGetOp( input [15:0] row, input [2:0] col, input isCorf,
 		5:   aluOp = OP_EXT;
 
 		default:
-			unique case( 1'b1)
+			unique0 case( 1'b1)
 				row[1]:
-					unique case( col)
+					unique0 case( col)
 					2: aluOp = OP_SUB;
 					3: aluOp = OP_SUBC;
 					4,6: aluOp = OP_SLAA;
 					endcase
 				
 				row[2]:
-					unique case( col)
+					unique0 case( col)
 					2: aluOp = OP_ADD;
 					3: aluOp = OP_ADDC;
 					4: aluOp = OP_ASR;
 					endcase
 
 				row[3]:
-					unique case( col)
+					unique0 case( col)
 					2: aluOp = OP_ADDX;
 					3: aluOp = isCorf ? OP_ABCD : OP_ADD;
 					4: aluOp = OP_ASL;
@@ -560,14 +560,14 @@ module aluGetOp( input [15:0] row, input [2:0] col, input isCorf,
 				
 				row[5],
 				row[6]:
-					unique case( col)
+					unique0 case( col)
 					2: aluOp = OP_SUB;
 					3: aluOp = OP_SUBC;
 					4: aluOp = OP_LSR;
 					endcase
 				
 				row[7]:					// MUL
-					unique case( col)
+					unique0 case( col)
 					2: aluOp = OP_SUB;
 					3: aluOp = OP_ADD;
 					4: aluOp = OP_ROXR;
@@ -576,28 +576,28 @@ module aluGetOp( input [15:0] row, input [2:0] col, input isCorf,
 				row[8]:
 					// OP_AND For EXT.L
 					// But would be more efficient to change ucode and use column 1 instead of col3 at ublock extr1!				
-					unique case( col)
+					unique0 case( col)
 					2: aluOp = OP_EXT;
 					3: aluOp = OP_AND;
 					4: aluOp = OP_ROXR;
 					endcase
                
 				row[9]:
-					unique case( col)
+					unique0 case( col)
 					2: aluOp = OP_SUBX;
 					3: aluOp = OP_SBCD;
 					4: aluOp = OP_ROL;
 					endcase
 
 				row[10]:
-					unique case( col)
+					unique0 case( col)
 					2: aluOp = OP_SUBX;
 					3: aluOp = OP_SUBC;
 					4: aluOp = OP_ROR;
 					endcase
                 
 				row[11]:
-					unique case( col)
+					unique0 case( col)
 					2: aluOp = OP_SUB0;
 					3: aluOp = OP_SUB0;
 					4: aluOp = OP_ROXL;


### PR DESCRIPTION
This patch to the verilator version of fx68 allows simulation of a small test ROM using a recent Verilator without having to disable asserts.

(It needs more exhaustive testing - it's possible there are more cases I haven't bumped into yet, but it at least gets as far as the disk/hand image in Kickstart 1.3)

